### PR TITLE
Generate and export M:module_info/0,1

### DIFF
--- a/src/mlfe_codegen.erl
+++ b/src/mlfe_codegen.erl
@@ -436,6 +436,7 @@ module_info_helpers_test() ->
     Mod = module_info_helpers_test,
     {module, Mod} = code:load_binary(Mod, "module_info_helpers_test.beam", Bin),
     ?assertEqual(Mod, Mod:module_info(module)),
-    ?assert(is_list(Mod:module_info())).
+    ?assert(is_list(Mod:module_info())),
+    true = code:delete(Mod).
 
 -endif.

--- a/src/mlfe_codegen.erl
+++ b/src/mlfe_codegen.erl
@@ -31,8 +31,12 @@ gen(#mlfe_module{}=Mod) ->
     CompiledExports = [gen_export(E) || E <- Exports],
     {ok, cerl:c_module(
            cerl:c_atom(ModuleName),
+           [gen_export({"module_info", 0}),
+            gen_export({"module_info", 1})] ++
            CompiledExports,
            [],
+           [module_info0(ModuleName),
+            module_info1(ModuleName)] ++
            CompiledFuns)
     }.
 
@@ -220,6 +224,19 @@ gen_expr(Env, #var_binding{name={symbol, _, N}, to_bind=E1, expr=E2}) ->
     cerl:c_let([cerl:c_var(list_to_atom(N))], 
                gen_expr(Env, E1),
                gen_expr(Env, E2)).
+
+module_info0(ModuleName) ->
+    gen_module_info(ModuleName, []).
+
+module_info1(ModuleName) ->
+    gen_module_info(ModuleName, [cerl:c_var(item)]).
+
+gen_module_info(ModuleName, Params) ->
+    Body = cerl:c_call(cerl:c_atom(erlang),
+                       cerl:c_atom(get_module_info),
+                       [cerl:c_atom(ModuleName) | Params]),
+    NewF = cerl:c_fun(Params, Body),
+    {cerl:c_fname(module_info, length(Params)), NewF}.
     
 
 -ifdef(TEST).
@@ -413,4 +430,12 @@ multi_type_guard_test() ->
     ?assertEqual('not_int', Mod:test(1.3)),
     true = code:delete(Mod).
     
+module_info_helpers_test() ->
+    Code = "module module_info_helpers_test\n",
+    {ok, _, Bin} = parse_and_gen(Code),
+    Mod = module_info_helpers_test,
+    {module, Mod} = code:load_binary(Mod, "module_info_helpers_test.beam", Bin),
+    ?assertEqual(Mod, Mod:module_info(module)),
+    ?assert(is_list(Mod:module_info())).
+
 -endif.


### PR DESCRIPTION
Here's the proposed patch for #6. Please let me know if it needs any polishing (though the line count is quite small...).

The changes in action:

```erlang
3> [M1, M2] = mlfe:compile({files, Files}).         
...
[{compiled_module,basic_adt,"basic_adt.beam",
                  <<70,79,82,49,0,0,2,44,66,69,65,77,65,116,111,109,0,0,0,
                    64,0,0,0,8,...>>},
 {compiled_module,type_import,"type_import.beam",
                  <<70,79,82,49,0,0,2,56,66,69,65,77,65,116,111,109,0,0,0,
                    77,0,0,0,...>>}]
4> code:load_binary(basic_adt, "basic_adt.beam", element(4, M1)).
{module,basic_adt}
5> basic_adt:<hitting TAB>
len/1          module_info/0  module_info/1  
5> basic_adt:len([1,2,3]).
** exception error: no true branch found when evaluating an if expression
     in function  basic_adt:len/1 
6> basic_adt:module_info().
[{module,basic_adt},
 {exports,[{module_info,0},{module_info,1},{len,1}]},
 {attributes,[{vsn,[28918006886475732050522193344556526446]}]},
 {compile,[{options,[from_core]},
           {version,"6.0.1"},
           {time,{2016,7,3,16,48,8}},
           {source,"/home/erszcz/work/erszcz/mlfe"}]},
 {native,false},
 {md5,<<21,193,103,209,111,55,171,46,6,129,67,193,244,
        101,107,110>>}]
```