### PR TITLE
Fix #2 (Rename call_erlang keyword)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ export a function called `add_2_and_2_test`:
       let res = add 2 2 in
       match res with
           4 -> :ok
-        | _ -> call_erlang :erlang :error [no_match] with _ -> meaningless_return
+        | _ -> beam :erlang :error [no_match] with _ -> meaningless_return
 
 Any test that throws an exception will fail so the above would work
 but if we replaced `add/2` with `add x y = x + (y + 1)` we'd get a
@@ -425,7 +425,7 @@ _all_ message sends to that process will be a type error.
 ## Current FFI
 The FFI is quite limited at present and operates as follows:
 
-    call_erlang :a_module :a_function [3, "different", "arguments"] with
+    beam :a_module :a_function [3, "different", "arguments"] with
        (ok, _) -> :ok
      | (error, _) -> :error
 

--- a/Tour.md
+++ b/Tour.md
@@ -269,7 +269,7 @@ Explicit type specifications for variables and functions is a planned feature fo
 While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term `()` if we don't need or want to pass anything specific.  Let's introduce the basic foreign-function interface here to call an Erlang printing method:
 
     print_hello () =
-      call_erlang :io :format ["Hello~n", []] with _ -> ()
+      beam :io :format ["Hello~n", []] with _ -> ()
 
 ## The Foreign Function Interface<a id="sec-4-1" name="sec-4-1"></a>
 
@@ -277,10 +277,10 @@ The FFI is how we call any non-MLFE code in the Erlang VM (e.g. Erlang, [Elixir]
 
 Here we're using a simple guard function so that we know the FFI expression is returning characters (an Erlang string):
 
-    call_erlang :io_lib :format ["This will contain the integer 3:  ~w", [3]] with
+    beam :io_lib :format ["This will contain the integer 3:  ~w", [3]] with
       cs, is_chars cs -> cs
 
-The FFI `call_erlang` expects the external module and function as atoms and then a list of arguments to send.  The arguments sent are **not** type checked but the return value in the pattern matching clauses **is** checked.
+The FFI `beam` expects the external module and function as atoms and then a list of arguments to send.  The arguments sent are **not** type checked but the return value in the pattern matching clauses **is** checked.
 
 ## Built-In Functions<a id="sec-4-2" name="sec-4-2"></a>
 
@@ -413,12 +413,12 @@ While the above test is type checked and will happily be compiled, we lack asser
           true -> :passed
         | false ->
             let msg = format_msg "Not equal:  ~w and ~w" x y in
-            call_erlang :erlang :error [msg] with _ -> :failed
+            beam :erlang :error [msg] with _ -> :failed
     
     // formats a failure message:
     format_msg base x y =
-      let m = call_erlang :io_lib :format [base, [x, y]] with msg -> msg in
-      call_erlang :lists :flatten [m] with msg, is_chars msg -> msg
+      let m = beam :io_lib :format [base, [x, y]] with msg -> msg in
+      beam :lists :flatten [m] with msg, is_chars msg -> msg
 
 It's a bit of an open question right now as to whether we'll try to pull test assertions from EUnit's include file directly (likely the preferable way) or implement some matchers directly in MLFE.
 

--- a/Tour.org
+++ b/Tour.org
@@ -202,7 +202,7 @@ Explicit type specifications for variables and functions is a planned feature fo
 While functions with no arguments aren't supported ("nullary" or arity of zero) we can use the unit term ~()~ if we don't need or want to pass anything specific.  Let's introduce the basic foreign-function interface here to call an Erlang printing method:
 #+BEGIN_SRC
 print_hello () =
-  call_erlang :io :format ["Hello~n", []] with _ -> ()
+  beam :io :format ["Hello~n", []] with _ -> ()
 #+END_SRC
 
 ** The Foreign Function Interface
@@ -210,10 +210,10 @@ The FFI is how we call any non-MLFE code in the Erlang VM (e.g. Erlang, [[http:/
 
 Here we're using a simple guard function so that we know the FFI expression is returning characters (an Erlang string):
 #+BEGIN_SRC
-call_erlang :io_lib :format ["This will contain the integer 3:  ~w", [3]] with
+beam :io_lib :format ["This will contain the integer 3:  ~w", [3]] with
   cs, is_chars cs -> cs
 #+END_SRC
-The FFI ~call_erlang~ expects the external module and function as atoms and then a list of arguments to send.  The arguments sent are *not* type checked but the return value in the pattern matching clauses *is* checked.
+The FFI ~beam~ expects the external module and function as atoms and then a list of arguments to send.  The arguments sent are *not* type checked but the return value in the pattern matching clauses *is* checked.
 
 ** Built-In Functions
 The basic infix comparisons are all available and can be used in pattern matching guards:
@@ -354,12 +354,12 @@ test_equal x y =
       true -> :passed
     | false ->
         let msg = format_msg "Not equal:  ~w and ~w" x y in
-        call_erlang :erlang :error [msg] with _ -> :failed
+        beam :erlang :error [msg] with _ -> :failed
 
 -- formats a failure message:
 format_msg base x y =
-  let m = call_erlang :io_lib :format [base, [x, y]] with msg -> msg in
-  call_erlang :lists :flatten [m] with msg, is_chars msg -> msg
+  let m = beam :io_lib :format [base, [x, y]] with msg -> msg in
+  beam :lists :flatten [m] with msg, is_chars msg -> msg
 #+END_SRC
 
 It's a bit of an open question right now as to whether we'll try to pull test assertions from EUnit's include file directly (likely the preferable way) or implement some matchers directly in MLFE.

--- a/src/mlfe_ast_gen.erl
+++ b/src/mlfe_ast_gen.erl
@@ -1001,7 +1001,7 @@ ffi_test_() ->
                                                    tail={nil, 1}},
                                            tail={nil, 0}}}}},
                    test_parse(
-                     "call_erlang :io :format [\"One is ~s~n\", [1]] with\n"
+                     "beam :io :format [\"One is ~s~n\", [1]] with\n"
                      " _ -> 0"))
     ].
 

--- a/src/mlfe_codegen.erl
+++ b/src/mlfe_codegen.erl
@@ -479,7 +479,7 @@ ffi_test() ->
     Code =
         "module ffi_test\n\n"
         "export a/1\n\n"
-        "a x = call_erlang :erlang :list_to_integer [x] with\n"
+        "a x = beam :erlang :list_to_integer [x] with\n"
         "  1 -> :one\n"
         "| _ -> :not_one\n",
     {ok, _, Bin} = parse_and_gen(Code),
@@ -497,7 +497,7 @@ type_guard_test() ->
         "module type_guard_test\n\n"
         "export check/1\n\n"
         "check x = \n"
-        "call_erlang :erlang :* [x, x] with\n"
+        "beam :erlang :* [x, x] with\n"
         "   i, is_integer i -> i\n"
         " | f -> 0",
     {ok, _, Bin} = parse_and_gen(Code),
@@ -515,7 +515,7 @@ multi_type_guard_test() ->
         "module multi_type_guard_test\n\n"
         "export check/1\n\n"
         "check x = \n"
-        "call_erlang :erlang :* [x, x] with\n"
+        "beam :erlang :* [x, x] with\n"
         "   i, is_integer i, i == 4 -> :got_four\n"
         " | i, is_integer i, i > 5, i < 20 -> :middle\n"
         " | i, is_integer i -> :just_int\n"

--- a/src/mlfe_parser.yrl
+++ b/src/mlfe_parser.yrl
@@ -63,7 +63,7 @@ send
 receive after
 spawn
 
-call_erlang
+beam
 
 type_check_tok
 
@@ -315,7 +315,7 @@ spawn_pid -> spawn symbol terms:
 defn -> terms assign simple_expr : make_define('$1', '$3').
 binding -> let defn in simple_expr : make_binding('$2', '$4').
 
-ffi_call -> call_erlang atom atom cons with match_clauses:
+ffi_call -> beam atom atom cons with match_clauses:
   #mlfe_ffi{module='$2',
             function_name='$3',
             args='$4',

--- a/src/mlfe_scan.xrl
+++ b/src/mlfe_scan.xrl
@@ -55,7 +55,7 @@ let         : {token, {'let', TokenLine}}.
 in          : {token, {in, TokenLine}}.
 match       : {token, {match, TokenLine}}.
 with        : {token, {with, TokenLine}}.
-call_erlang : {token, {call_erlang, TokenLine}}.
+beam        : {token, {beam, TokenLine}}.
 module      : {token, {module, TokenLine}}.
 export      : {token, {export, TokenLine}}.
 type        : {token, {type_declare, TokenLine}}.

--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -2295,16 +2295,16 @@ terminating_mutual_recursion_test() ->
 ffi_test_() ->
     [?_assertMatch({t_int, _},
                    top_typ_of(
-                     "call_erlang :io :format [\"One is ~w~n\", [1]] with\n"
+                     "beam :io :format [\"One is ~w~n\", [1]] with\n"
                      " _ -> 1")),
      ?_assertMatch({error, {cannot_unify, undefined, 1, t_atom, t_int}},
                    top_typ_of(
-                     "call_erlang :a :b [1] with\n"
+                     "beam :a :b [1] with\n"
                      "  (:ok, x) -> 1\n"
                      "| (:error, x) -> :error")),
      ?_assertMatch({{t_arrow, [{unbound, _, _}], t_atom}, _},
                    top_typ_of(
-                     "f x = call_erlang :a :b [x] with\n"
+                     "f x = beam :a :b [x] with\n"
                      "  1 -> :one\n"
                      "| _ -> :not_one"))
 
@@ -2340,7 +2340,7 @@ type_guard_test_() ->
      %% type in the pattern for use in the resulting expression:
      ?_assertMatch({t_int, _},
                    top_typ_of(
-                     "call_erlang :a :b [5] with\n"
+                     "beam :a :b [5] with\n"
                      "   :one -> 1\n"
                      " | i, i == 2.0 -> 2\n"
                      " | i, is_integer i -> i\n")),
@@ -2348,7 +2348,7 @@ type_guard_test_() ->
      %% should result in a type error:
      ?_assertMatch({error, {cannot_unify, _, _, t_int, t_float}},
                    top_typ_of(
-                     "call_erlang :a :b [2] with\n"
+                     "beam :a :b [2] with\n"
                      "   i, i == 1.0 -> i\n"
                      " | i, is_integer i -> i")),
      %% Guards should work with items from inside tuples:

--- a/test_files/basic_module_with_tests.mlfe
+++ b/test_files/basic_module_with_tests.mlfe
@@ -11,12 +11,12 @@ test "add 2 and 2" = test_equal (add 2 2) 4
 test "subtract 2 from 4" = test_equal (sub 4 2) 3
 
 format_msg base x y =
-  let m = call_erlang :io_lib :format [base, [x, y]] with msg -> msg in
-  call_erlang :lists :flatten [m] with msg, is_chars msg -> msg
+  let m = beam :io_lib :format [base, [x, y]] with msg -> msg in
+  beam :lists :flatten [m] with msg, is_chars msg -> msg
 
 test_equal x y =
   match (x == y) with
       true -> :passed
     | false ->
         let msg = format_msg "Not equal:  ~w and ~w" x y in
-        call_erlang :erlang :error [msg] with _ -> :failed
+        beam :erlang :error [msg] with _ -> :failed

--- a/test_files/string_concat.mlfe
+++ b/test_files/string_concat.mlfe
@@ -2,6 +2,6 @@ module string_concat
 
 export hello/1
 
-hello x = call_erlang :string :concat [c"Hello, ", x] with
+hello x = beam :string :concat [c"Hello, ", x] with
       s, is_chars s -> s
       


### PR DESCRIPTION
Rename call_erlang to beam, as discussed in the ticket[1].

[1] https://github.com/j14159/mlfe/issues/2