### PR TITLE
Avoid leaking processes while type checking.

### DIFF
--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -77,7 +77,7 @@
              | t_map()
              | t_tuple()
              | t_clause()
-             | typer:t_cell().  % a reference cell for a type.
+             | mlfe_typer:t_cell().  % a reference cell for a type.
 
 %%% ## MLFE AST Nodes
 

--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -3206,6 +3206,16 @@ no_process_leak_test() ->
     {ok, _, _, M} = mlfe_ast_gen:parse_module(0, Code),
     ProcessesBefore = length(erlang:processes()),
     ?assertMatch({ok, _}, type_modules([M])),
-    ProcessesAfter = length(erlang:processes()),
+    ProcessesAfter = wait_for_processes_to_die(ProcessesBefore, 10),
     ?assertEqual(ProcessesBefore, ProcessesAfter).
+
+wait_for_processes_to_die(ExpectedNumProcesses, 0)            ->
+    length(erlang:processes());
+wait_for_processes_to_die(ExpectedNumProcesses, AttemptsLeft) ->
+    case length(erlang:processes()) of
+        ExpectedNumProcesses -> ExpectedNumProcesses;
+        _WrongNumProcesses   ->
+            timer:sleep(10),
+            wait_for_processes_to_die(ExpectedNumProcesses, AttemptsLeft-1)
+    end.
 -endif.

--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -993,7 +993,7 @@ type_modules(Mods) ->
         catch
             E:T ->
                 io:format("mlfe_typer:type_modules/2 crashed with ~p:~p~n"
-                          "Stacktrace: ~p~n", [E, T, erlang:get_stacktrace()]),
+                          "Stacktrace:~n~p~n", [E, T, erlang:get_stacktrace()]),
                 exit({error, "mlfe_typer:type_modules/2 crashed"})
         end
     end),


### PR DESCRIPTION
This is achieved by performing the type checking in a separate
process, and linking all reference cells to that process.