### PR TITLE
Fix type declarations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: erlang
 otp_release:
-  - 19.0
   - 18.3
   - 18.2
 
@@ -24,7 +23,6 @@ before_install:
 before_script: [] # Need to do this, or travis will use rebar2!
 
 script:
-  - rebar3 dialyzer --update-plt true --succ-typings false
-  - rebar3 dialyzer --update-plt false --succ-typings true
+  - rebar3 dialyzer
   - rebar3 xref
   - rebar3 eunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 before_script: [] # Need to do this, or travis will use rebar2!
 
 script:
-  - rebar3 dialyzer
+  - rebar3 dialyzer --update-plt true --succ-typings false
+  - rebar3 dialyzer --update-plt false --succ-typings true
   - rebar3 xref
   - rebar3 eunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: erlang
 otp_release:
+  - 19.0
   - 18.3
   - 18.2
 
@@ -23,6 +24,6 @@ before_install:
 before_script: [] # Need to do this, or travis will use rebar2!
 
 script:
-  - rebar3 dialyzer
+  - if [ "$TRAVIS_OTP_RELEASE" != "19.0" ]; then rebar3 dialyzer; else echo "dialyzer disabled on OTP 19.0"; fi
   - rebar3 xref
   - rebar3 eunit

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ ML-flavoured Erlang.
 # TLDR; How Do I Use It?
 Make sure the following are installed:
 
-- Erlang R18.2 or above (I often use [packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html)
-but mostly use R19 locally from [kerl](https://github.com/kerl/kerl)
+- Erlang OTP 18.2 or above (I often use [packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html)
+but mostly use OTP 19 locally from [kerl](https://github.com/kerl/kerl)
 of late)
 - [Rebar3](https://rebar3.org)
 
@@ -132,10 +132,13 @@ tests in `mlfe_typer.erl`.
 ## Prerequisites
 You will generally want the following two things installed:
 
-- Erlang R18.2 or above (I often use [packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html)
-but mostly use R19 locally from [kerl](https://github.com/kerl/kerl)
+- Erlang/OTP 18.2 or above (I often use [packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html)
+but mostly use OTP 19 locally from [kerl](https://github.com/kerl/kerl)
 of late)
 - [Rebar3](https://rebar3.org)
+
+Note: While MLFE builds and all tests pass on OTP 19, dialyzer fails due to a spec bug that
+has been fixed in OTP master.
 
 ## Writing MLFE with Rebar3
 Thanks to [@tsloughter](https://github.com/tsloughter)'s

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
 {erl_opts, [debug_info]}.
 {xrl_opts, [{report, true}, {verbose, true}]}.
 {deps, []}.
+{dialyzer, [{warnings, [unknown]}]}.

--- a/src/mlfe.app.src
+++ b/src/mlfe.app.src
@@ -22,7 +22,8 @@
   {registered, []},
   {mod, {'mlfe_app', []}},
   {applications,
-   [kernel,
+   [compiler,
+    kernel,
     stdlib
    ]},
   {env,[]},

--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -38,9 +38,9 @@
 %% allowed to be sent messages.
 -type t_pid() :: {t_pid, typ()}.
 
--type t_cons() :: {t_cons, typ(), t_list()}.
--type t_nil() :: t_nil.
--type t_list() :: t_cons() | t_nil().
+-type t_receiver() :: {t_receiver, typ(), typ()}.
+
+-type t_list() :: {t_list, typ()}.
 
 -type t_map() :: {t_map, typ(), typ()}.
 
@@ -77,7 +77,10 @@
              | t_map()
              | t_tuple()
              | t_clause()
-             | typer:t_cell().  % a reference cell for a type.
+             | t_pid()
+             | t_receiver()
+             | mlfe_type()
+             | mlfe_typer:t_cell().  % a reference cell for a type.
 
 %%% ## MLFE AST Nodes
 

--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -79,7 +79,6 @@
              | t_clause()
              | t_pid()
              | t_receiver()
-             | mlfe_type()
              | mlfe_typer:t_cell().  % a reference cell for a type.
 
 %%% ## MLFE AST Nodes
@@ -174,7 +173,7 @@
                         | mlfe_map_type().
 
 -type mlfe_constructor_name() :: {type_constructor, integer(), string()}.
--record(mlfe_constructor, {type=undefined :: typ(),
+-record(mlfe_constructor, {type=undefined :: typ() | mlfe_type(),
                            name={type_constructor, 0, ""} :: mlfe_constructor_name(),
                            arg=none :: none
                                      | mlfe_base_type()

--- a/src/mlfe_codegen.erl
+++ b/src/mlfe_codegen.erl
@@ -112,7 +112,7 @@ gen_expr(_, {chars, _, Cs}) ->
 gen_expr(_, {string, _, S}) ->
     cerl:c_binary(literal_binary(S, utf8));
 gen_expr(_, {'_', _}) ->
-    cerl:c_var("_");
+    cerl:c_var('_');
 gen_expr(Env, {symbol, _, V}) ->
     case proplists:get_value(V, Env) of
         Arity when is_integer(Arity) ->


### PR DESCRIPTION
The types should really be defined in `erl` files, and not in `hrl` files, but I leave fixing that for later.

This also shows the danger of "unknown types". Unfortunately, it doesn't seem like rebar3 warns about them.