### PR TITLE
Fix constructor args

### DIFF
--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -850,6 +850,8 @@ inst_constructor_arg({mlfe_list, ElementType}, Vs) ->
 inst_constructor_arg({mlfe_map, KeyType, ValType}, Vs) ->
     new_cell({t_map, inst_constructor_arg(KeyType, Vs),
                      inst_constructor_arg(ValType, Vs)});
+inst_constructor_arg({mlfe_pid, MsgType}, Vs) ->
+    new_cell({t_pid, inst_constructor_arg(MsgType, Vs)});
 inst_constructor_arg(#mlfe_type{name={type_name, _, N}, vars=Vars}, Vs) ->
     ADT_vars = [{VN, proplists:get_value(VN, Vs)} || {type_var, _, VN} <- Vars],
     new_cell(#adt{name=N, vars=ADT_vars});
@@ -2639,7 +2641,7 @@ type_constructor_test_() ->
 type_constructor_with_pid_arg_test() ->
     Code = "module constructor\n\n"
            "type t = Constructor pid int\n\n"
-           "a x = x + 1\n\n"
+           "a x = receive with i -> x + i\n\n"
            "make () = Constructor (spawn a 2)",
      ?assertMatch({ok, _}, module_typ_and_parse(Code)).
 

--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -847,6 +847,9 @@ inst_constructor_arg(#mlfe_type_tuple{members=Ms}, Vs) ->
     new_cell({t_tuple, [inst_constructor_arg(M, Vs) || M <- Ms]});
 inst_constructor_arg({mlfe_list, ElementType}, Vs) ->
     new_cell({t_list, inst_constructor_arg(ElementType, Vs)});
+inst_constructor_arg({mlfe_map, KeyType, ValType}, Vs) ->
+    new_cell({t_map, inst_constructor_arg(KeyType, Vs),
+                     inst_constructor_arg(ValType, Vs)});
 inst_constructor_arg(#mlfe_type{name={type_name, _, N}, vars=Vars}, Vs) ->
     ADT_vars = [{VN, proplists:get_value(VN, Vs)} || {type_var, _, VN} <- Vars],
     new_cell(#adt{name=N, vars=ADT_vars});

--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -845,6 +845,8 @@ inst_constructor_arg({type_var, _, N}, Vs) ->
     proplists:get_value(N, Vs);
 inst_constructor_arg(#mlfe_type_tuple{members=Ms}, Vs) ->
     new_cell({t_tuple, [inst_constructor_arg(M, Vs) || M <- Ms]});
+inst_constructor_arg({mlfe_list, ElementType}, Vs) ->
+    new_cell({t_list, inst_constructor_arg(ElementType, Vs)});
 inst_constructor_arg(#mlfe_type{name={type_name, _, N}, vars=Vars}, Vs) ->
     ADT_vars = [{VN, proplists:get_value(VN, Vs)} || {type_var, _, VN} <- Vars],
     new_cell(#adt{name=N, vars=ADT_vars});

--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -2602,8 +2602,41 @@ type_constructor_test_() ->
                                              vars=[{type_var, 1, "x"}]}]}},
                        #mlfe_constructor{
                           name={type_constructor, 1, "Nil"},
-                          arg=none}]}]))
+                          arg=none}]}])),
+     ?_assertMatch(
+        {{t_arrow,
+          [{unbound, V, _}],
+          #adt{name="t", vars=[]}},
+         _},
+        top_typ_with_types(
+          "f x = Constructor [1]",
+          [#mlfe_type{
+              name={type_name, 1, "t"},
+              vars=[],
+              members=[#mlfe_constructor{
+                          name={type_constructor, 1, "Constructor"},
+                          arg={mlfe_list, t_int}}]}])),
+     ?_assertMatch(
+        {{t_arrow,
+          [{unbound, V, _}],
+          #adt{name="t", vars=[]}},
+         _},
+        top_typ_with_types(
+          "f x = Constructor #{1 => \"one\"}",
+          [#mlfe_type{
+              name={type_name, 1, "t"},
+              vars=[],
+              members=[#mlfe_constructor{
+                          name={type_constructor, 1, "Constructor"},
+                          arg={mlfe_map, t_int, t_string}}]}]))
     ].
+
+type_constructor_with_pid_arg_test() ->
+    Code = "module constructor\n\n"
+           "type t = Constructor pid int\n\n"
+           "a x = x + 1\n\n"
+           "make () = Constructor (spawn a 2)",
+     ?assertMatch({ok, _}, module_typ_and_parse(Code)).
 
 %%% Type constructors that use underscores in pattern matches to discard actual
 %%% values should work, depends on correct recursive renaming.


### PR DESCRIPTION
Adds supports for maps, lists and pids as constructor args.