### PR TITLE
Compiled output distinguishes between maps and records, bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ ML-flavoured Erlang.
 Make sure the following are installed:
 
 - Erlang OTP 18.2 or above (I often use [packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html)
-but mostly use OTP 19 locally from [kerl](https://github.com/kerl/kerl)
-of late)
+but mostly use OTP 19.1 locally from [kerl](https://github.com/kerl/kerl) now)
 - [Rebar3](https://rebar3.org)
 
 Make a new project with `rebar3 new app your_app_name` and in the
@@ -49,8 +48,8 @@ suggest possible union types if there isn't an appropriate one in scope.
 
 ## What Works Already
 
-- type inferencer with ADTs.  Tuples and maps for product types and
-  unions for sum.
+- type inferencer with ADTs.  Tuples, maps, and records for product types and
+  unions for sum.  Please note that MLFE's records are not compatible with Erlang records as the former are currently compiled to maps.
 - compile type-checked source to `.beam` binaries
 - simple FFI to Erlang
 - type-safe message flows for processes defined inside MLFE
@@ -116,7 +115,7 @@ especially with respect to comments.
 
 # Using It
 It's not very usable yet but the tests should give a relatively clear picture as to
-where I'm going.  `test_files` contains some example source files used
+where we're going.  `test_files` contains some example source files used
 in unit tests.  You can call `mlfe:compile({files,
 [List, Of, File, Names, As, Strings]}, [list, of, options])` or `mlfe:compile({text,
 CodeAsAString}, [options, again])` for now.
@@ -133,12 +132,8 @@ tests in `mlfe_typer.erl`.
 You will generally want the following two things installed:
 
 - Erlang/OTP 18.2 or above (I often use [packages from Erlang Solutions](https://www.erlang-solutions.com/resources/download.html)
-but mostly use OTP 19 locally from [kerl](https://github.com/kerl/kerl)
-of late)
+but mostly use OTP 19.1 locally from [kerl](https://github.com/kerl/kerl) now)
 - [Rebar3](https://rebar3.org)
-
-Note: While MLFE builds and all tests pass on OTP 19, dialyzer fails due to a spec bug that
-has been fixed in OTP master.
 
 ## Writing MLFE with Rebar3
 Thanks to [@tsloughter](https://github.com/tsloughter)'s
@@ -227,7 +222,8 @@ Most of the basic Erlang data types are supported:
   32798: type=int, size=16, signed=false>>`, etc
 - tuples, `("a", :tuple, "of arity", 4)`
 - maps (basic support), e.g. `#{:atom_key => "string value"}`.  These
-  are statically typed as lists are (generics, parametric polymorphism).
+are statically typed as lists are (generics, parametric polymorphism).
+- records (basic support), these look a bit like OCaml and Elm records, e.g. `{x=1, hello="world"}` will produce a record with an `x: int` and `hello: string` field.  Please see the  [language tour](https://github.com/j14159/mlfe/blob/master/Tour.md) for more details.
 - pids, these are also parametric (like lists, "generics").  If you're
   including them in a type you can do something like `type t = int |
   pid int` for a type that covers integers and processes that receive integers.
@@ -290,13 +286,12 @@ and
 
 will type to a tuple of `integer`, `float`.
 
-Since strings are currently just lists of characters as in Erlang
-proper, only the first clause will ever match:
+Since strings are currently compiled as UTF-8 Erlang binaries, only the first clause will ever match:
 
-    type my_list_string_union = list int | string
+    type my_binary_string_union = binary | string
 
     match "Hello, world" with
-        l, is_list l -> l
+        b, is_binary b -> b
       | s, is_string s -> s
 
 Further, nullary type constructors are encoded as atoms and unary
@@ -465,7 +460,6 @@ A very incomplete list:
 - support for typing anything other than a raw source file.  I need to
   investigate reading/writing beam file annotations to help with this
   I suspect.
-- records, especially with structural matching.
 - pattern matching in function declarations directly rather than in
   the body.
 - type annotations/restrictions/ascriptions.  I'm toying with the idea

--- a/Tour.org
+++ b/Tour.org
@@ -176,6 +176,70 @@ Maps are type-checked as lists are but have separate types for their keys vs the
  -}
 #{:key1 => "value 1", "key 2" => "value 2"}
 #+END_SRC
+*** Records
+Records can be created ad-hoc wherever you like as in OCaml and Elm and you can pattern match on the structure of records as well.
+#+BEGIN_SRC
+{x=1, hello="world"}  -- a literal record
+
+-- we have basic structural matching:
+match {x=1, hello="world"} with
+  {x=xx} -> xx
+
+{- We have "row polymorphism" which means that if you call the following
+   function with {x=1, hello="world"}, the return type does not lose the
+   information about the hello field.  The return type of calling the
+   function below with that record will be (int, {x: int, hello: string}).
+-}
+x_in_a_tuple my_rec = 
+  match my_rec with
+    {x=xx} -> (xx, my_rec)
+#+END_SRC
+
+**** What's Row Polymorphism?
+The key thing we're after from row polymorphism is not losing information.  For example in Java if we had the following:
+#+BEGIN_SRC
+public interface IHasX {
+    public int getX();
+}
+
+public class HasXY implements IHasX {
+    public final int x;
+    public final String hello;
+        
+    public HasXY(int x, String hello) {
+        this.x = x;
+        this.hello = hello;  
+    }
+
+    public int getX() { return x; }
+    public String getHello() { return hello; }
+}
+
+public IHasX identity(IHasX i) {
+    return i;
+}
+#+END_SRC
+
+The return of ~identity(new HasXY(1, "world"))~ "loses" the information that the passed-in argument has a ~hello~ member of type ~String~.  
+
+#+BEGIN_SRC
+identity my_rec =
+  match my_rec with
+    {x=_} -> my_rec
+#+END_SRC
+
+The return of ~identity({x=1, hello="world"})~ above is still the type ~{x: int, hello: string}~ in MLFE  even though the function ~identity~ only cares about the field ~x: int~.
+
+**** What's Missing?
+There's not yet a way to access individual fields of a record without pattern matching (e.g. ~let my_rec = {x=1, hello="world"} in x.x~) nor is there a way to modify a record by making a copy with new or replaced fields.  The syntax currently under consideration:
+#+BEGIN_SRC
+-- add an integer field named z to a record with x and y:
+let xy = {x=1, y=2} in
+{xy | z=3}
+#+END_SRC
+We should be able to use the above to both "update" fields in a record and also to extend a record with new fields.
+
+There are currently no plans to enable the removal of record fields.
 *** PIDs
 Process identifiers (references to processes to which we can send messages) are typed with the kind of messages they are able to receive.  The type of process that only knows how to receive strings can be expressed as ~pid string~.  We'll cover processes and PIDs in a bit more detail later but if you're unfamiliar with them from Erlang, [[http://learnyousomeerlang.com/the-hitchhikers-guide-to-concurrency][The Hitchhiker's Guide to Concurrency]] from Learn You Some Erlang is a great place to start.
 * Functions

--- a/src/mlfe.erl
+++ b/src/mlfe.erl
@@ -253,5 +253,14 @@ polymorphic_record_test() ->
     [M] = compile_and_load(["test_files/polymorphic_record_test.mlfe"], []),
     ?assertEqual(<<"bar">>, M:with_y({})),
     code:delete(M).
+
+%% A pattern match that matches records and maps with the same key should
+%% correctly distinguish between maps and records that are compiled as
+%% maps.
+record_vs_map_match_order_test() ->
+    [M] = compile_and_load(["test_files/record_map_match_order.mlfe"], []),
+    ?assertEqual(1, M:check_map({})),
+    ?assertEqual(2, M:check_record({})),
+    code:delete(M).
     
 -endif.

--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -242,9 +242,16 @@
                         val=undefined :: mlfe_value_expression()}).
 -type mlfe_map_pair() :: #mlfe_map_pair{}.
 
+%% The `structure` field tracks what we're actually using the map for.
+%% The code generation stage will add a member to the compiled map that
+%% indicates what the purpose of the map is so that pattern matches can
+%% be correct, e.g. we don't want the order of maps and records to matter
+%% in a pattern match because then compilation details are a concern for
+%% a user.
 -record(mlfe_map, {type=undefined :: typ(),
                    line=0 :: integer(),
                    is_pattern=false :: boolean(),
+                   structure=map :: map | record,
                    pairs=[] :: list(mlfe_map_pair())}).
 -type mlfe_map() :: #mlfe_map{}.
 

--- a/test_files/polymorphic_record_test.mlfe
+++ b/test_files/polymorphic_record_test.mlfe
@@ -11,3 +11,11 @@ with_y () =
   match res with
     (_, {foo=ff}) -> ff
 
+{- `x=_` here is causing an error in compilation due to multiple
+   occurences of `_`.
+ -}
+{- with_y_and_throwaway_x() =
+  let res = f {x=1, foo="bar"} in
+  match res with
+    (_, {x=_, foo=ff}) -> ff -}
+    

--- a/test_files/record_map_match_order.mlfe
+++ b/test_files/record_map_match_order.mlfe
@@ -1,0 +1,14 @@
+module record_map_match_order
+
+export check_map/1, check_record/1
+
+type record_map_union = map atom int | {x: int}
+
+get_x rec_or_map =
+  match rec_or_map with
+      #{:x => xx} -> xx
+    | {x = xx}    -> xx
+
+check_map () = get_x #{:x => 1}
+
+check_record () = get_x {x=2}


### PR DESCRIPTION
Records are compiled to maps but if we have a type that unions maps and records and then pattern match on this type, whichever pattern occurred first (the map or the record) would always match.  Now the compiled output includes a synthetic key and value that we use in pattern matches for explicit record or map matching.

Fixed a nasty bug with polymorphic maps, things weren't typing correctly when using functions that took maps polymorphic in the types of their values.  Further bug discovered where functions polymorphic on an ADT's variables weren't getting their members deep copied correctly.