### PR TITLE
Danabr complex types fix

### DIFF
--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -210,6 +210,7 @@
           name={type_name, -1, ""} :: mlfe_type_name(),
           vars=[]                  :: list(mlfe_type_var()),
           members=[]               :: list(mlfe_constructor()
+                                           | mlfe_type_var()
                                            | mlfe_types())
          }).
 -type mlfe_type() :: #mlfe_type{}.


### PR DESCRIPTION
Closes #34 and #37 based on @danabr's work.  The `when is_pid` test mentioned in #37 is no longer required, I believe this was fixed as a by-product of the recent records work.