### PR TITLE
Can raise exceptions (throw, error, exit)

### DIFF
--- a/src/mlfe.erl
+++ b/src/mlfe.erl
@@ -277,7 +277,6 @@ records_with_x_module_test() ->
     ?assertEqual(5, M:get_x(M:make_xy(5, 6))),
     code:delete(M).
 
-
 %% A pattern match that matches records and maps with the same key should
 %% correctly distinguish between maps and records that are compiled as
 %% maps.
@@ -287,4 +286,15 @@ record_vs_map_match_order_test() ->
     ?assertEqual(2, M:check_record({})),
     code:delete(M).
     
+raise_errors_test() ->
+    [M] = compile_and_load(["test_files/error_tests.mlfe"], []),
+    ?assertException(throw, <<"this should be a throw">>, M:raise_throw(unit)),
+    ?assertException(exit, <<"exit here">>, M:raise_exit(unit)),
+    ?assertException(error, <<"and an error">>, M:raise_error(unit)),
+
+    ?assertException(throw, <<"oh no zero!">>, M:throw_or_int(0)),
+    ?assertEqual(4, M:throw_or_int(2)),
+    code:delete(M).
+    
+
 -endif.

--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -100,6 +100,11 @@
 -type mlfe_bool() :: {bool, integer(), boolean()}.
 -type mlfe_atom() :: {atom, integer(), atom()}.
 
+-type mlfe_error() :: {raise_error, 
+                       integer(), 
+                       throw|error|exit, 
+                       mlfe_value_expression()}.
+
 %%% The variable _, meaning "don't care":
 -type mlfe_any() :: {any, integer()}.
 
@@ -386,7 +391,8 @@
                          | mlfe_type_check()
                          | mlfe_binding()
                          | mlfe_fun_def()
-                         | mlfe_type_import().
+                         | mlfe_type_import()
+                         | mlfe_error().
 
 -record(fun_binding, {def :: mlfe_fun_def(),
                       expr :: mlfe_expression()

--- a/src/mlfe_codegen.erl
+++ b/src/mlfe_codegen.erl
@@ -144,6 +144,11 @@ gen_expr(#env{module_funs=Funs}=Env, {symbol, _, V}) ->
         undefined ->
             {Env, cerl:c_var(list_to_atom(V))}
     end;
+
+gen_expr(Env, {raise_error, _, Kind, Expr}) ->
+    {Env2, ExprAST} = gen_expr(Env, Expr),
+    {Env2, cerl:c_call(cerl:c_atom(erlang), cerl:c_atom(Kind), [ExprAST])};
+
 gen_expr(Env, {nil, _}) ->
     {Env, cerl:c_nil()};
 gen_expr(Env, #mlfe_cons{head=H, tail=T}) ->

--- a/src/mlfe_parser.yrl
+++ b/src/mlfe_parser.yrl
@@ -43,6 +43,8 @@ send_to
 receive_block
 spawn_pid
 
+error
+
 compare type_check guard guards
 ffi_call
 expr simple_expr.
@@ -64,6 +66,8 @@ bin_open bin_close bin_unit bin_size bin_end bin_endian bin_sign bin_text_encodi
 open_brace close_brace
 map_open map_arrow
 match with '|' '->'
+
+raise_error
 
 send
 receive after
@@ -285,6 +289,11 @@ tuple -> '(' tuple_list ')' :
 
 infix -> term op term : make_infix('$2', '$1', '$3').
 
+%% ----- Errors (including throw, exit) --------------
+error -> raise_error term:
+  {_, L, Kind} = '$1',
+  {raise_error, L, list_to_atom(Kind), '$2'}.
+
 term -> const : '$1'.
 term -> tuple : '$1'.
 term -> infix : '$1'.
@@ -297,6 +306,7 @@ term -> record : '$1'.
 term -> module_fun : '$1'.
 term -> '(' simple_expr ')' : '$2'.
 term -> type_apply : '$1'.
+term -> error : '$1'.
 
 terms -> term : ['$1'].
 terms -> term terms : ['$1'|'$2'].

--- a/src/mlfe_scan.xrl
+++ b/src/mlfe_scan.xrl
@@ -65,6 +65,7 @@ send        : {token, {send, TokenLine}}.
 receive     : {token, {'receive', TokenLine}}.
 after       : {token, {'after', TokenLine}}.
 test        : {token, {'test', TokenLine}}.
+error|exit|throw : {token, {'raise_error', TokenLine, TokenChars}}.
 
 true|false : {token, {boolean, TokenLine, list_to_atom(TokenChars)}}.
 

--- a/test_files/error_tests.mlfe
+++ b/test_files/error_tests.mlfe
@@ -1,0 +1,14 @@
+module error_tests
+
+export raise_throw/1, raise_error/1, raise_exit/1, throw_or_int/1
+
+raise_throw () = throw "this should be a throw"
+
+raise_exit () = exit "exit here"
+
+raise_error () = error "and an error"
+
+throw_or_int x = match x with
+    0 -> throw "oh no zero!"
+  | _ -> x * 2
+  


### PR DESCRIPTION
They type as a standard type variable so raising an exception will unify
with any other term.  Still considering treating exceptions a little
like receivers where the effect wraps an enclosing expression.

Closes #52 