### PR TITLE
Patterns for function args

### DIFF
--- a/src/mlfe.erl
+++ b/src/mlfe.erl
@@ -295,6 +295,16 @@ raise_errors_test() ->
     ?assertException(throw, <<"oh no zero!">>, M:throw_or_int(0)),
     ?assertEqual(4, M:throw_or_int(2)),
     code:delete(M).
+
+function_pattern_args_test() ->
+    [M] = compile_and_load(["test_files/function_pattern_args.mlfe"], []),
+    ?assertEqual(true, M:is_zero(0)),
+    ?assertEqual(false, M:is_zero(5)),
+    ?assertEqual(true, M:both_zero(0, 0)),
+    ?assertEqual(false, M:both_zero(0, 1)),
+    ?assertEqual(false, M:both_zero(1, 0)),
+    ?assertEqual(false, M:both_zero(5, 4)),
+    code:delete(M).
     
 
 -endif.

--- a/src/mlfe.erl
+++ b/src/mlfe.erl
@@ -300,11 +300,22 @@ function_pattern_args_test() ->
     [M] = compile_and_load(["test_files/function_pattern_args.mlfe"], []),
     ?assertEqual(true, M:is_zero(0)),
     ?assertEqual(false, M:is_zero(5)),
+
     ?assertEqual(true, M:both_zero(0, 0)),
     ?assertEqual(false, M:both_zero(0, 1)),
     ?assertEqual(false, M:both_zero(1, 0)),
     ?assertEqual(false, M:both_zero(5, 4)),
-    code:delete(M).
+
+    ?assertEqual(1, M:get_x(M:make_xy(1, 2))),
+
+    ?assertEqual({'Some', 2}, M:get_opt_x(M:make_xy(2, 3))),
+    ?assertEqual('None', M:get_opt_x(M:make_y(2))),
     
+    ?assertEqual({'Some', 4}, M:doubler(2)),
+    ?assertEqual({'Some', 4}, M:double_maybe_x(M:make_xy(2, 3))),
+    ?assertEqual('None', M:double_maybe_x(M:make_y(2))),
+    
+    code:delete(M).
+
 
 -endif.

--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -447,8 +447,9 @@
 -record (mlfe_fun_def, {
            type=undefined :: typ(),
            name=undefined :: undefined|mlfe_symbol(),
-           args=[] :: list(mlfe_symbol() | mlfe_unit()),
-           body=undefined :: undefined|mlfe_expression()
+           arity=0 :: integer(),
+           versions=[] :: list({mlfe_value_expression(),
+                                mlfe_expression()})
           }).
 
 -type mlfe_fun_def() :: #mlfe_fun_def{}.

--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -444,12 +444,17 @@
                     }).
 -type mlfe_apply() :: #mlfe_apply{}.
 
+-record(mlfe_fun_version, {
+          line=0 :: integer(),
+          args=[] :: list(mlfe_value_expression()),
+          body=undefined :: undefined|mlfe_expression()
+         }).
+
 -record (mlfe_fun_def, {
            type=undefined :: typ(),
            name=undefined :: undefined|mlfe_symbol(),
            arity=0 :: integer(),
-           versions=[] :: list({list(mlfe_value_expression()),
-                                mlfe_expression()})
+           versions=[] :: list(#mlfe_fun_version{})
           }).
 
 -type mlfe_fun_def() :: #mlfe_fun_def{}.

--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -448,7 +448,7 @@
            type=undefined :: typ(),
            name=undefined :: undefined|mlfe_symbol(),
            arity=0 :: integer(),
-           versions=[] :: list({mlfe_value_expression(),
+           versions=[] :: list({list(mlfe_value_expression()),
                                 mlfe_expression()})
           }).
 

--- a/src/mlfe_ast_gen.erl
+++ b/src/mlfe_ast_gen.erl
@@ -78,12 +78,6 @@ drop_dupes_preserve_order([H|T], [H|_]=Memo) ->
 drop_dupes_preserve_order([H|T], Memo) ->
     drop_dupes_preserve_order(T, [H|Memo]).
 
-rebind_fun_pattern_args([], _NV, _Map, _Env, Memo) ->
-    lists:reverse(Memo);
-rebind_fun_pattern_args([A|T], NV, MN, Map, Memo) ->
-    {NV2, Map2, A2} = make_bindings(NV, MN, Map, A),
-    rebind_fun_pattern_args(T, NV2, MN, Map2, [A2|Memo]).
-
 rebind_and_validate_module(_, {error, _} = Err) ->
     Err;
 rebind_and_validate_module(NextVarNum, {ok, #mlfe_module{}=Mod}) ->

--- a/src/mlfe_codegen.erl
+++ b/src/mlfe_codegen.erl
@@ -130,7 +130,7 @@ gen_fun_patterns(Env, #mlfe_fun_def{name={symbol, _, N}, arity=A, versions=Vs}) 
     VarNames = ["pat_var_" ++ integer_to_list(X) || X <- lists:seq(1, A)],
     %% Nest matches:
     FName = cerl:c_fname(list_to_atom(N), A),
-    Args = [cerl:c_var(cerl:c_atom(X)) || X <- VarNames],
+    Args = [cerl:c_var(list_to_atom(X)) || X <- VarNames],
     [TopVar|_] = VarNames,
     B = cerl:c_case(
           cerl:c_values(Args),

--- a/src/mlfe_codegen.erl
+++ b/src/mlfe_codegen.erl
@@ -353,11 +353,7 @@ gen_expr(Env, #mlfe_send{message=M, pid=P}) ->
     {Env, cerl:c_call(cerl:c_atom('erlang'), cerl:c_atom('!'), [PExp, MExp])};
 
 gen_expr(#env{module_funs=Funs}=Env, #fun_binding{def=F, expr=E}) ->
-    #mlfe_fun_def{name={symbol, _, N}, versions=[{A, _}]} = F,
-    Arity = case A of
-                [{unit, _}] -> 1;
-                L -> length(L)
-            end,
+    #mlfe_fun_def{name={symbol, _, N}, arity=Arity} = F,
     NewEnv = Env#env{module_funs=[{N, Arity}|Funs]},
     {_, Exp} = gen_expr(NewEnv, E),
     {Env, cerl:c_letrec([gen_fun(NewEnv, F)], Exp)};

--- a/src/mlfe_codegen.erl
+++ b/src/mlfe_codegen.erl
@@ -95,16 +95,36 @@ gen_fun(Env,
     A = [cerl:c_var('_unit')],
     {_, B} = gen_expr(Env, Body),
     {FName, cerl:c_fun(A, B)};
-gen_fun(Env, 
-        #mlfe_fun_def{
-           name={symbol, _, N}, 
-           versions=[#mlfe_fun_version{args=Args, body=Body}]}) ->
-    FName = cerl:c_fname(list_to_atom(N), length(Args)),
-    A = [cerl:c_var(list_to_atom(X)) || {symbol, _, X} <- Args],
-    {_, B} = gen_expr(Env, Body),
-    {FName, cerl:c_fun(A, B)};
+gen_fun(Env, #mlfe_fun_def{name={symbol, _, N}, versions=Vs}=Def) ->
+    case Vs of
+        %% If there's a single version with only symbol and/or unit
+        %% args, don't compile a pattern match:
+        [#mlfe_fun_version{args=Args, body=Body}] ->
+            case needs_pattern(Args) of
+                false ->
+                    FName = cerl:c_fname(list_to_atom(N), length(Args)),
+                    A = [cerl:c_var(list_to_atom(X)) || {symbol, _, X} <- Args],
+                    {_, B} = gen_expr(Env, Body),
+                    {FName, cerl:c_fun(A, B)};
+                true ->
+                    %% our single version has more than symbols and unit:
+                    gen_fun_patterns(Env, Def)
+            end;
+        _ ->
+            %% more than one version:
+            gen_fun_patterns(Env, Def)
+    end.
 
-gen_fun(Env, #mlfe_fun_def{name={symbol, _, N}, arity=A, versions=Vs}) ->
+needs_pattern(Args) ->
+    case lists:filter(fun({unit, _})      -> false;
+                         ({symbol, _, _}) -> false;
+                         (_)              -> true
+                      end, Args) of
+        [] -> false;
+        _  -> true
+    end.
+
+gen_fun_patterns(Env, #mlfe_fun_def{name={symbol, _, N}, arity=A, versions=Vs}) ->
     %% We need to manufacture variable names that we'll use in the
     %% nested pattern matches:
     VarNames = ["pat_var_" ++ integer_to_list(X) || X <- lists:seq(1, A)],
@@ -118,7 +138,9 @@ gen_fun(Env, #mlfe_fun_def{name={symbol, _, N}, arity=A, versions=Vs}) ->
     {FName, cerl:c_fun(Args, B)}.
 
 gen_fun_version(Env, #mlfe_fun_version{args=Args, body=Body}) ->
+    io:format("Args for fun version ~w~n", [Args]),
     Patt = [Expr || {_, Expr} <- [gen_expr(Env, A) || A <- Args]],
+    io:format("Args vs pattern are~n~w~n~w~n", [Args, Patt]),
     {_, BodyExp} = gen_expr(Env, Body),
     cerl:c_clause(Patt, BodyExp).
 
@@ -183,6 +205,7 @@ gen_expr(Env, #mlfe_binary{segments=Segs}) ->
     {Env2, Bits} = gen_bits(Env, Segs), 
     {Env2, cerl:c_binary(Bits)};
 gen_expr(Env, #mlfe_map{is_pattern=true}=M) ->
+    io:format("Generate map pattern!~n", []),
     Annotated = annotate_map_type(M),
     F = fun(P, {E, Ps}) -> 
                 {E2, P2} = gen_expr(E, P),
@@ -204,6 +227,7 @@ gen_expr(Env, #mlfe_map_add{to_add=#mlfe_map_pair{key=K, val=V}, existing=B}) ->
     {_, VExp} = gen_expr(Env, V),
     {Env, cerl:c_call(cerl:c_atom(maps), cerl:c_atom(put), [KExp, VExp, M])};
 gen_expr(Env, #mlfe_map_pair{is_pattern=true, key=K, val=V}) ->
+    io:format("Generate map pattern!~n", []),
     {Env2, KExp} = gen_expr(Env, K),
     {Env3, VExp} = gen_expr(Env2, V),
 

--- a/src/mlfe_parser.yrl
+++ b/src/mlfe_parser.yrl
@@ -449,7 +449,7 @@ make_infix(Op, A, B) ->
 make_define([{symbol, _, _} = Name|A], Expr) ->
     case validate_args(A) of
         {ok, Args} ->
-            #mlfe_fun_def{name=Name, args=Args, body=Expr};
+            #mlfe_fun_def{name=Name, arity=length(Args), versions=[{Args, Expr}]};
         {error, _} = E ->
             E
     end;
@@ -472,7 +472,7 @@ validate_args([NonSymbol|_], _) ->
     {error, {invalid_fun_parameter, NonSymbol}}.
 
 %% Convert a nullary def into a variable binding:
-make_binding(#mlfe_fun_def{name=N, args=[], body=B}, Expr) ->
+make_binding(#mlfe_fun_def{name=N, versions=[{[], B}]}, Expr) ->
     #var_binding{name=N, to_bind=B, expr=Expr};
 make_binding(Def, Expr) ->
     #fun_binding{def=Def, expr=Expr}.

--- a/src/mlfe_parser.yrl
+++ b/src/mlfe_parser.yrl
@@ -278,6 +278,11 @@ record -> open_brace record_members close_brace:
   {_, L} = '$1',
   #mlfe_record{line=L, arity=length('$2'), members='$2'}.
 
+%% Need to permit "empty" records for pattern matches:
+record -> open_brace close_brace:
+  {_, L} = '$1',
+  #mlfe_record{line=L, arity=0, members=[]}.
+
 unit -> '(' ')':
   {_, L} = '$1',
   {unit, L}.

--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -4004,33 +4004,6 @@ function_argument_pattern_test_() ->
                                              #adt{vars=[{_, {unbound, B, _}}]}}}]}},
                  module_typ_and_parse(Code))
       end
-    , fun() ->
-              Code =
-                  "module fun_pattern_with_adt\n\n"
-                  "type option 'a = None | Some 'a\n\n"
-                  "my_map _ None = None\n\n"
-                  "my_map f Some a = Some (f a)\n\n"
-                  "doubler x = x * x\n\n"
-                  "foo = my_map doubler 2",
-              ?assertMatch(
-                 {error, {cannot_unify, _, _, #adt{}, t_int}},
-                 module_typ_and_parse(Code))
-      end
-    , fun() ->
-              Code =
-                  "module fun_pattern_with_adt\n\n"
-                  "type option 'a = None | Some 'a\n\n"
-                  "my_map _ None = None\n\n"
-                  "my_map f Some a = Some (f a)\n\n"
-                  "doubler x = x * x\n\n"
-                  "get_x {x=x} = x\n\n"
-                  "foo () = "
-                  "  let rec = {x=1, y=2} in "
-                  "  my_map doubler (get_x rec)",
-              ?assertMatch(
-                 {error, {cannot_unify, _, _, #adt{}, t_int}},
-                 module_typ_and_parse(Code))
-      end
     ].
 
 no_process_leak_test() ->

--- a/src/mlfe_typer.erl
+++ b/src/mlfe_typer.erl
@@ -4004,6 +4004,33 @@ function_argument_pattern_test_() ->
                                              #adt{vars=[{_, {unbound, B, _}}]}}}]}},
                  module_typ_and_parse(Code))
       end
+    , fun() ->
+              Code =
+                  "module fun_pattern_with_adt\n\n"
+                  "type option 'a = None | Some 'a\n\n"
+                  "my_map _ None = None\n\n"
+                  "my_map f Some a = Some (f a)\n\n"
+                  "doubler x = x * x\n\n"
+                  "foo = my_map doubler 2",
+              ?assertMatch(
+                 {error, {cannot_unify, _, _, #adt{}, t_int}},
+                 module_typ_and_parse(Code))
+      end
+    , fun() ->
+              Code =
+                  "module fun_pattern_with_adt\n\n"
+                  "type option 'a = None | Some 'a\n\n"
+                  "my_map _ None = None\n\n"
+                  "my_map f Some a = Some (f a)\n\n"
+                  "doubler x = x * x\n\n"
+                  "get_x {x=x} = x\n\n"
+                  "foo () = "
+                  "  let rec = {x=1, y=2} in "
+                  "  my_map doubler (get_x rec)",
+              ?assertMatch(
+                 {error, {cannot_unify, _, _, #adt{}, t_int}},
+                 module_typ_and_parse(Code))
+      end
     ].
 
 no_process_leak_test() ->

--- a/test_files/function_pattern_args.mlfe
+++ b/test_files/function_pattern_args.mlfe
@@ -1,6 +1,8 @@
 module function_pattern_args
 
-export is_zero/1, both_zero/2
+export is_zero/1, both_zero/2, make_xy/2, make_y/1, get_x/1, get_opt_x/1
+
+export double_maybe_x/1, doubler/1
 
 is_zero 0 = true
 
@@ -9,3 +11,25 @@ is_zero x = false
 both_zero 0 0 = true
 
 both_zero x y = false
+
+make_xy x y = {x=x, y=y}
+
+make_y y = {y=y}
+
+get_x {x=x} = x
+
+type option 'a = None | Some 'a
+
+get_opt_x {x=x} = Some x
+
+get_opt_x {} = None
+
+my_map f None = None
+
+my_map f (Some a) = Some (f a)
+
+double x = x * x
+
+doubler x = my_map double (Some x)
+
+double_maybe_x rec = my_map double (get_opt_x rec)

--- a/test_files/function_pattern_args.mlfe
+++ b/test_files/function_pattern_args.mlfe
@@ -1,0 +1,11 @@
+module function_pattern_args
+
+export is_zero/1, both_zero/2
+
+is_zero 0 = true
+
+is_zero x = false
+
+both_zero 0 0 = true
+
+both_zero x y = false


### PR DESCRIPTION
Can now define functions as a collection of the same name with different patterns.  Closes #54 