### PR TITLE
Types in a module default to private

### DIFF
--- a/src/mlfe.erl
+++ b/src/mlfe.erl
@@ -336,5 +336,12 @@ function_pattern_args_test() ->
     
     code:delete(M).
 
-
+radius_test() ->
+    [M1, M2] = compile_and_load(
+            ["test_files/radius.mlfe", 
+             "test_files/use_radius.mlfe"], 
+            []),
+    ?assertEqual(1, M1:test_radius(unit)),
+    code:delete(M1),
+    code:delete(M2).
 -endif.

--- a/src/mlfe.erl
+++ b/src/mlfe.erl
@@ -66,13 +66,7 @@ compile({text, Code}, Opts) ->
     end;
 
 compile({files, Filenames}, Opts) ->
-    Code = lists:foldl(
-             fun(FN, Acc) ->
-                     {ok, Device} = file:open(FN, [read, {encoding, utf8}]),
-                     Res = read_file(Device, []),
-                     ok = file:close(Device),
-                     [Res|Acc]
-             end, [], Filenames),
+    Code = load_files(Filenames),
     {ok, Mods} = type_modules(parse_modules(Code)),
     Compiled = lists:foldl(
                  fun(M, Acc) ->
@@ -80,6 +74,14 @@ compile({files, Filenames}, Opts) ->
                  end, [], Mods),
     Compiled.
 
+load_files(Filenames) ->
+    lists:foldl(
+      fun(FN, Acc) ->
+              {ok, Device} = file:open(FN, [read, {encoding, utf8}]),
+              Res = read_file(Device, []),
+              ok = file:close(Device),
+              [Res|Acc]
+      end, [], Filenames).
 
 compile_module(#mlfe_module{name=N}=Mod, Opts) ->
     {ok, Forms} = mlfe_codegen:gen(Mod, Opts),
@@ -169,6 +171,23 @@ type_import_test() ->
     M = type_import,
     ?assertEqual(2, M:test_output(unit)),
     [code:delete(N) || N <- ModuleNames].
+
+type_imports_and_pattern_test() ->
+    Files = ["test_files/basic_adt.mlfe", "test_files/list_opts.mlfe"],
+    ModuleNames = compile_and_load(Files, []),
+    io:format("Compiled and loaded modules are ~w~n", [ModuleNames]),
+    LO = list_opts,
+    ADT = basic_adt,
+    ?assertEqual({'Some', 1}, LO:head_opt({'Cons', {1, {'Cons', {2, 'Nil'}}}})),
+    ?assertEqual('None', LO:head_opt('Nil')),
+    [code:delete(N) || N <- ModuleNames].
+
+private_types_error_test() ->
+    Files = ["test_files/unexported_adts.mlfe", "test_files/list_opts.mlfe"],
+    Code = load_files(Files),
+    ?assertEqual(
+       {error, {unexported_type, list_opts, basic_adt, "my_list"}},
+       type_modules(parse_modules(Code))).
 
 basic_pid_test() ->
     Files = ["test_files/basic_pid_test.mlfe"],

--- a/src/mlfe_ast.hrl
+++ b/src/mlfe_ast.hrl
@@ -392,6 +392,7 @@
                          | mlfe_binding()
                          | mlfe_fun_def()
                          | mlfe_type_import()
+                         | mlfe_type_export()
                          | mlfe_error().
 
 -record(fun_binding, {def :: mlfe_fun_def(),
@@ -462,6 +463,10 @@
 -record(mlfe_type_import, {module=undefined :: atom(),
                            type=undefined :: string()}).
 -type mlfe_type_import() :: #mlfe_type_import{}.
+
+-record(mlfe_type_export, {line=0 :: integer(),
+                            names=[] :: list(string())}).
+-type mlfe_type_export() :: #mlfe_type_export{}.
 
 -record(mlfe_module, {
           name=no_module :: atom(),

--- a/src/mlfe_ast_gen.erl
+++ b/src/mlfe_ast_gen.erl
@@ -158,6 +158,9 @@ update_memo(#mlfe_module{name=Name}, {module, DupeName}) ->
     {error, {module_rename, Name, DupeName}};
 update_memo(#mlfe_module{type_imports=Imports}=M, #mlfe_type_import{}=I) ->
     {ok, M#mlfe_module{type_imports=Imports ++ [I]}};
+update_memo(#mlfe_module{type_exports=Exports}=M, #mlfe_type_export{}=I) ->
+    #mlfe_type_export{names=Names} = I,
+    {ok, M#mlfe_module{type_exports = Exports ++ Names}};
 update_memo(#mlfe_module{function_exports=Exports}=M, {export, Es}) ->
     {ok, M#mlfe_module{function_exports=Es ++ Exports}};
 update_memo(#mlfe_module{functions=Funs}=M, #mlfe_fun_def{} = Def) ->

--- a/src/mlfe_parser.yrl
+++ b/src/mlfe_parser.yrl
@@ -57,7 +57,7 @@ module export
 type_declare type_constructor type_var base_type base_list base_map base_pid
 test
 ':'
-use
+import_type export_type
 boolean int float atom string chars '_'
 symbol module_fun
 assign int_math float_math minus plus
@@ -99,7 +99,7 @@ comment -> comment_lines :
                 line=L,
                 text=Chars}.
 
-type_import -> use module_fun:
+type_import -> import_type module_fun:
   {module_fun, _, MF} = '$2',
   [Mod, Type] = string:tokens(MF, "."),
   #mlfe_type_import{module=list_to_atom(Mod), type=Type}.

--- a/src/mlfe_parser.yrl
+++ b/src/mlfe_parser.yrl
@@ -20,7 +20,7 @@ const
 type poly_type poly_type_decl type_vars type_member type_members type_expr
 type_expressions type_tuple type_tuple_list
 type_apply
-type_import
+type_import type_export types_to_export
 
 test_case
 
@@ -103,6 +103,14 @@ type_import -> import_type module_fun:
   {module_fun, _, MF} = '$2',
   [Mod, Type] = string:tokens(MF, "."),
   #mlfe_type_import{module=list_to_atom(Mod), type=Type}.
+
+types_to_export -> symbol : ['$1'].
+types_to_export -> symbol ',' types_to_export : ['$1'|'$3'].
+
+type_export -> export_type types_to_export :
+  {_, L}  = '$1',
+  Names = [N || {symbol, _, N} <- '$2'],
+  #mlfe_type_export{line=L, names=Names}.
 
 module_def -> module atom : {module, '$1'}.
 
@@ -421,6 +429,7 @@ expr -> test_case : '$1'.
 expr -> module_def : '$1'.
 expr -> export_def : '$1'.
 expr -> type_import : '$1'.
+expr -> type_export : '$1'.
 expr -> defn : '$1'.
 
 Erlang code.

--- a/src/mlfe_scan.xrl
+++ b/src/mlfe_scan.xrl
@@ -59,7 +59,8 @@ beam        : {token, {beam, TokenLine}}.
 module      : {token, {module, TokenLine}}.
 export      : {token, {export, TokenLine}}.
 type        : {token, {type_declare, TokenLine}}.
-use         : {token, {use, TokenLine}}.
+export_type : {token, {export_type, TokenLine}}.
+import_type : {token, {import_type, TokenLine}}.
 spawn       : {token, {spawn, TokenLine}}.
 send        : {token, {send, TokenLine}}.
 receive     : {token, {'receive', TokenLine}}.

--- a/test_files/basic_adt.mlfe
+++ b/test_files/basic_adt.mlfe
@@ -1,6 +1,7 @@
 module basic_adt
 
 export len/1
+-- export_type my_list
 
 {- simple linked list,
    multi-line comment.

--- a/test_files/list_opts.mlfe
+++ b/test_files/list_opts.mlfe
@@ -1,0 +1,11 @@
+module list_opts
+
+export head_opt/1
+
+import_type basic_adt.my_list
+
+import_type basic_adt.opt
+
+head_opt Cons (h, _) = Some h
+
+head_opt Nil = None

--- a/test_files/radius.mlfe
+++ b/test_files/radius.mlfe
@@ -1,0 +1,14 @@
+module radius
+
+type radius = Radius int 
+
+export make_radius/1, radius_to_int/1
+
+make_radius i = 
+  match i with
+    x, is_integer x -> Radius x
+
+radius_to_int r = 
+  match r with
+    Radius i -> i
+    

--- a/test_files/type_import.mlfe
+++ b/test_files/type_import.mlfe
@@ -1,6 +1,6 @@
 module type_import
 
-use basic_adt.my_list
+import_type basic_adt.my_list
 
 export test_output/1
 

--- a/test_files/unexported_adts.mlfe
+++ b/test_files/unexported_adts.mlfe
@@ -1,8 +1,13 @@
+{- We want to ensure that if the types exist but aren't exported we get an
+   appropriate compiler error.
+
+   The module name doesn't match the filename so that we can reuse the
+   list_opts module for tests.
+ -}
+
 module basic_adt
 
 export len/1
-
-export_type my_list, opt
 
 {- simple linked list,
    multi-line comment.

--- a/test_files/use_radius.mlfe
+++ b/test_files/use_radius.mlfe
@@ -1,0 +1,5 @@
+module use_radius
+
+export test_radius/1
+
+test_radius () = (radius.radius_to_int (radius.make_radius 1)) 


### PR DESCRIPTION
Importing and exporting via `import_type` and `export_type`.

@danabr I'd be curious to hear any thoughts on these changes if you have a moment as they're based on an example you brought up.